### PR TITLE
Preserve HTML EntityNames converting to and from the DOM

### DIFF
--- a/APLSource/Main/DOM2HTML.aplf
+++ b/APLSource/Main/DOM2HTML.aplf
@@ -6,7 +6,8 @@
      _←InjectStyleElement ⍵
      _←InjectScriptElement ⍵
      m←AddXMLSpace↑,ConstructQXI ⍵
-     t←RemoveXMLSpace ⎕XML 4↑[1]m
+     m[;2]←('\&(.+;)'⎕R((⎕UCS 27),'\1'))m[;2]   ⍝ Esacpe EntityName start
+     t←RemoveXMLSpace(⎕XML⍠('UnknownEntity' 'Preserve'))4↑[1]m
      t←t InjectHTML m[;4]~0
      ⍵.Tag≢'html':t
      t←⍵ InjectStyle t

--- a/APLSource/Main/HTML2DOM.aplf
+++ b/APLSource/Main/HTML2DOM.aplf
@@ -2,6 +2,8 @@
      ⍝ ⍵ ←→ HTML
      ⍝ ← ←→ DOM
      0=≢⍵:⍬
+     xml←(⎕XML⍠('Whitespace' 'Preserve')('UnknownEntity' 'Preserve'))⍵
+     xml[;2]←('\x1B'⎕R'\&')xml[;2]
      {⍵⌷⍨⍳1=⍴⍵}0{
          m←⍵
          0=≢m:⍺
@@ -9,5 +11,5 @@
          p←⍺{⍺ New 3↑1↓⍵}¨↓b⌿m
          m[;0]-←1
          p⊣p ∇¨1↓¨b⊂[0]m
-     }⎕XML ⍵
+     }xml
  }


### PR DESCRIPTION
Test

```
v←'<p>Spaces before and after the next&nbsp;tags <strong><em>selection</em></strong> are dropped. Also &lt;, along with &gt; are now represented correectly.</p>'
v≡DOM2HTML HTML2DOM v
```

Close #12 
Close #11 