### PR TITLE
Make tab controls look like tabs (theme-aware folder style) + fix DataGrid top border

### DIFF
--- a/APLSource/Main/DataGrid/CSS.aplf
+++ b/APLSource/Main/DataGrid/CSS.aplf
@@ -39,6 +39,7 @@
      r.overflow←'hidden'
      r.width←'fit-content'
      r.height←'fit-content'
+     r.align_self←'start' ⍝ pin to top; default 'stretch' + overflow:hidden clips the collapsed top border once the table overflows (populated grid)
      ⍝ **********************
      r←s Rule'tbody'
      r.cursor←'cell'

--- a/APLSource/Main/Tabs/CSS.aplf
+++ b/APLSource/Main/Tabs/CSS.aplf
@@ -4,27 +4,43 @@
      s←Rule'.tabs'
      ⍝ *****************
      r←s Rule'nav'
-     r.padding←'3px'
      r.display←'flex'
      r.gap←'.25rem'
+     r.padding←'.35rem .5rem 0 .5rem' ⍝ top+side room; no bottom so tabs meet the content's top edge
+     r.border_bottom←'1px solid var(--border-color)' ⍝ the tab strip owns its baseline (stable, independent of the panel's own border)
      ⍝ *********************
+     ⍝ Every tab: a boxed "folder" with rounded top corners (not an all-round button)
      r←s Rule'>nav>button'
-     ⍝ r.display←'flex'
-     r.gap←'.5rem'
-     r.border←'none'
-     r.border_radius←'5px'
-     r.background_color←'DimGray' ⍝ 'DarkSlateGray'
-     r.min_width←'15rem'
-     ⍝ r.text_align←'left'
+     r.font←'inherit'               ⍝ constant size, matches page text (no small inactive tab)
+     r.padding←'.4rem 1rem'
+     r.border←'1px solid var(--border-color)'
+     r.border_bottom←'none'
+     r.border_top_left_radius←'7px'
+     r.border_top_right_radius←'7px'
+     r.margin_bottom←'-1px'         ⍝ overlap the content's top border
+     r.background_color←'color-mix(in srgb, currentColor 10%, transparent)' ⍝ subtle raised chip, theme-adaptive
+     r.color←'inherit'              ⍝ take the theme's text colour (dark & light)
+     r.opacity←'.8'                 ⍝ muted while inactive
+     r.cursor←'pointer'
+     ⍝ ******************
+     r←s Rule'>nav>button:hover'
+     r.opacity←'1'
+     r.background_color←'color-mix(in srgb, currentColor 18%, transparent)'
      ⍝ ******************
      r←s Rule'>section'
      r.flex←1
-     ⍝ Active button
+     ⍝ A DataGrid used as a tab panel must not draw its own top edge: the tab strip's
+     ⍝ baseline is that line, and the active tab connects into the grid across it.
+     r←s Rule'section .DataGrid thead th'
+     r.border_top_color←'transparent'
+     ⍝ Active tab: connects into the content (never a bigger font)
      r←s Rule'.active-tab'
-     r.font_size←'larger'
-     r.border←'1px solid gray'
-     r.color←'white' ⍝  'var(--selected-text-color)'
-     r.background_color←'steelblue' ⍝ 'var(--selected-background-color)'
+     r.opacity←'1'
+     r.color←'var(--text-color)' ⍝  'var(--selected-text-color)'
+     r.background_color←'var(--background-color)'    ⍝ merge with the panel below
+     r.position←'relative'          ⍝ lift above the panel, which is painted later in the DOM…
+     r.z_index←'1'                  ⍝ …so the cover below actually lands on top of the grid's line
+     r.border_bottom←'1px solid var(--background-color)' ⍝ cut the line under the active tab
      ⍝ **************
      A.UnNestCSS s
  }


### PR DESCRIPTION
CSS-only changes to two widgets. No markup or API change.

## Tabs — `APLSource/Main/Tabs/CSS.aplf`

The tab controls rendered as filled, all-rounded grey buttons, with the active tab distinguished only by a larger font — so a tab strip read as a row of action buttons of unequal size. Reworked to a theme-aware **folder-tab** look:

- Folder tabs (top-only rounded corners, subtle theme-derived fill) instead of all-round grey buttons; fixed `min-width` removed.
- **Constant font size** — the active tab was `font-size: larger` while the base `<button>` had none (UA's small button font). Base button now uses `font: inherit`; active is marked by colour, not size.
- The **tab strip owns its baseline** (`nav { border-bottom: 1px solid var(--border-color) }`), so the tabs look identical regardless of the panel's own borders.
- The **active tab connects into its panel** (`position: relative; z-index: 1` + a `var(--background-color)` bottom border that opens the tab into the content).
- A **`DataGrid` used as a tab panel** no longer draws its own top edge (`.tabs section .DataGrid thead th { border-top-color: transparent }`), so the strip baseline is the single top line and the active tab merges into the grid.

Colours are all theme-derived (`currentColor`, `color-mix(...)`, `var(--border-color)`, `var(--accent-color-1, ...)`), verified on the `AbacusDark` default.

## DataGrid — `APLSource/Main/DataGrid/CSS.aplf`

Fixes a pre-existing bug: a grid's **top border disappears once it is populated**. The `table` is a CSS-grid item with the default `align-self: stretch`; when its content overflows it's stretched to the shorter track height and its own `overflow: hidden` clips the collapsed **top** border. Adding `align-self: start` pins the table to the top so the border survives. One line; preserves clipping and scrollbar layout.

## Testing

Checked in Chromium (the HTMLRenderer engine) with the CSVEditor demo and a second grid-in-a-tab app: active tab connects to the grid in both empty and populated states, tabs are equal size, correct on the dark default theme. Relies only on modern-Chromium CSS already used elsewhere in the project (`color-mix`, `var()` fallbacks).