### PR TITLE
Fix menu-bar captions shifting sideways on click (#87)

### DIFF
--- a/APLSource/Main/Menu/CSS.aplf
+++ b/APLSource/Main/Menu/CSS.aplf
@@ -58,12 +58,16 @@
      s.font_family←'Arial'
      s.text_wrap←'nowrap'
 
+     ⍝ Reserve the border box on every caption so gaining the focus indicator only
+     ⍝ changes the border *colour*, never the layout (otherwise the active caption
+     ⍝ widens and shoves the captions to its right 1-2px sideways).
+     r←s Rule'li'
+     r.border←'1px solid transparent'
 
-     r←s Rule'.Active'
-     r.border_bottom←'1px solid white'
-
+     ⍝ Only show the active-item indicator while the menu bar actually has focus;
+     ⍝ at rest the first caption must not carry a standing underline.
      r←s Rule'&:focus .Active'
-     r.border←'1px solid steelblue'
+     r.border_color←'steelblue'
 
 
      z,←s


### PR DESCRIPTION
## Problem

Clicking any caption in a menu bar nudged every caption to its **right** by 1–2 px. (Fixes #87.)

## Cause

`Main/Menu/CSS.aplf` gave the active caption a border only when it became active/focused:

```css
.MenuBar .Active        { border-bottom: 1px solid white }
.MenuBar:focus .Active  { border: 1px solid steelblue }
```

Since a plain `<li>` caption had no border, the focus rule added a real 1 px border on the **left and right** of the active item, widening its box and shoving the following captions sideways. The `.Active` white underline also stood permanently on the first caption at rest, which shouldn't show until the bar is focused.

## Fix

Reserve the border box up front on every caption, then only change its **colour** — never adding/removing a border, so the layout can't shift. Drop the standing underline; the active-item indicator now appears only while the menu bar actually has focus.

```apl
r←s Rule'li'
r.border←'1px solid transparent'   ⍝ reserve the box; colour changes never move neighbours

r←s Rule'&:focus .Active'
r.border_color←'steelblue'         ⍝ indicator shows only while the bar is focused
```

## Verification

Reproduced and confirmed fixed with a headless-Chromium mock of the menu bar in unfocused/focused states against a fixed reference line: with the change, the active caption still gets its steelblue indicator on focus, but the captions to its right no longer move, and the first caption carries no underline at rest.
