### PR TITLE
Menu-bar keyboard: F10 activate / Escape, click-to-close, no keystroke leak (#88, #83, #82)

### DIFF
--- a/APLSource/Main/Menu/NewMenuBar.aplf
+++ b/APLSource/Main/Menu/NewMenuBar.aplf
@@ -8,6 +8,11 @@
      b.BuildFunction←f
      b.class←'MenuBar'
      b.Onkeydown←A.FQP'OnKeyDownMenuBar'
+     ⍝ Opening a menu with the MOUSE must remember the outgoing focus too, so Escape restores it
+     ⍝ just as it does for F10 (Main.OnKeyDown stores _prevFocus there). Capture at pointerdown -
+     ⍝ before the click shifts focus onto the bar - and only when focus is coming from outside a
+     ⍝ menu (not the bar itself, not an already-open dropdown), so re-clicks don't clobber it.
+     b.onpointerdown←'if(document.activeElement!==this&&!document.activeElement.closest(''.menu'')){var a=document.activeElement;this._prevFocus=a;this._prevSel=(a.selectionStart!=null)?[a.selectionStart,a.selectionEnd,a.selectionDirection]:null;}'
      d←⍺.Document
      m←d(⍎f)0
      c←m.Content.Content

--- a/APLSource/Main/Menu/OnClickMenuBar.aplf
+++ b/APLSource/Main/Menu/OnClickMenuBar.aplf
@@ -2,6 +2,17 @@
      mi←⍵.CurrentTarget
      mb←mi.Parent
      i←mb.Content⍳mi
+     ⍝ The clicked caption is the open popover's invoker, so clicking it is exempt from the
+     ⍝ browser's light-dismiss - the menu will not close by itself. Without the guard below
+     ⍝ the click would fall straight through to ShowMenuBarMenu and re-show it, so the menu
+     ⍝ would never appear to close. So when this caption's menu is already open, hide it
+     ⍝ here instead - giving a proper click-to-open / click-to-close toggle.
+     o←mb.Document A.GetElementsByClass'menu'
+     mine←{0=≢⍵:⍬ ⋄ ⍵/⍨mb∘{6::0 ⋄ ⍺≡⍵.MenuBar}¨⍵}o
+     (i=mb.ActiveIndex)∧0<≢mine:mine A.ExecuteOnElement¨⊂'hidePopover()'
+     ⍝ Keep the 'Active' class in step with ActiveIndex (as MoveMenuBar does for the keyboard);
+     ⍝ otherwise a mouse click leaves the highlight stranded on the previously-active caption.
+     _←mb.Content[mb.ActiveIndex i]A.MoveClass'Active'
      mb.ActiveIndex←i
      ShowMenuBarMenu mb
  }

--- a/APLSource/Main/Menu/OnKeyDownMenuBar.aplf
+++ b/APLSource/Main/Menu/OnKeyDownMenuBar.aplf
@@ -7,8 +7,11 @@
      p≡'ArrowDown':⍵ ShowMenuBarMenu mb
      p≡'ArrowLeft':mb MoveMenuBar ¯1
      p≡'ArrowRight':mb MoveMenuBar 1
-     ⍝ Escape deactivates the bar: blur it and hand focus back to wherever F10 took it from:
-     p≡'Escape':mb.Document A.ExecuteJavaScript'var e=document.getElementById("',mb.id,'");e.blur();if(e._prevFocus&&e._prevFocus!==document.body){e._prevFocus.focus();}'
+     ⍝ Escape deactivates the bar: blur it and hand focus back to wherever F10 took it from, and
+     ⍝ put the caret/selection back exactly where it was (captured as _prevSel on F10/mouse entry).
+     ⍝ _keepSelection stops a SelectOnFocus:0 input from collapsing to the end first (see
+     ⍝ TextInput.InitSelectOnFocus); then setSelectionRange restores the precise range/direction.
+     p≡'Escape':mb.Document A.ExecuteJavaScript'var e=document.getElementById("',mb.id,'");e.blur();if(e._prevFocus&&e._prevFocus!==document.body){e._prevFocus._keepSelection=true;e._prevFocus.focus();if(e._prevSel){try{e._prevFocus.setSelectionRange(e._prevSel[0],e._prevSel[1],e._prevSel[2]);}catch(x){}}}'
      0
 
  }

--- a/APLSource/Main/Menu/OnKeyDownMenuBar.aplf
+++ b/APLSource/Main/Menu/OnKeyDownMenuBar.aplf
@@ -7,6 +7,8 @@
      p≡'ArrowDown':⍵ ShowMenuBarMenu mb
      p≡'ArrowLeft':mb MoveMenuBar ¯1
      p≡'ArrowRight':mb MoveMenuBar 1
+     ⍝ Escape deactivates the bar: blur it and hand focus back to wherever F10 took it from:
+     p≡'Escape':mb.Document A.ExecuteJavaScript'var e=document.getElementById("',mb.id,'");e.blur();if(e._prevFocus&&e._prevFocus!==document.body){e._prevFocus.focus();}'
      0
 
  }

--- a/APLSource/Main/OnKeyDown.aplf
+++ b/APLSource/Main/OnKeyDown.aplf
@@ -17,7 +17,7 @@
      ⍝ the MenuBar's own key handlers then navigate (arrows) and open menus (Enter/↓).
      ⍝ Only consume F10 when a menu bar exists, so apps without one still receive the key.
      mb←{p≢'F10':⍬ ⋄ ⍵ GetElementsByClass'MenuBar'}d
-     0<≢mb:{⍵.Document ExecuteJavaScript'var e=document.getElementById("',⍵.id,'");e._prevFocus=document.activeElement;e.focus();'}⊃mb
+     0<≢mb:{⍵.Document ExecuteJavaScript'var e=document.getElementById("',⍵.id,'");var a=document.activeElement;e._prevFocus=a;e._prevSel=(a&&a.selectionStart!=null)?[a.selectionStart,a.selectionEnd,a.selectionDirection]:null;e.focus();'}⊃mb
      _←OnKeyDownGlobal ⍵  ⍝ 0  ⍝ Handle main menu shortcuts
      d←⍵.Document
      e←⎕NS''

--- a/APLSource/Main/OnKeyDown.aplf
+++ b/APLSource/Main/OnKeyDown.aplf
@@ -2,6 +2,10 @@
      ⍝ On keydown in body, for menubar
      d←⍵.Document
      0<≢d GetElementsByTag'dialog':0
+     ⍝ An open dropdown menu owns the keyboard (it light-dismisses on Escape itself). Don't
+     ⍝ let its keystrokes bubble on and fire the app's KeyDown handler - e.g. Escape must
+     ⍝ close the menu only, not reach a user handler that might read it as "close the app" (#82).
+     0<≢d GetElementsByClass'menu':0
      k←⍵.Code
      b←⍵.(CtrlKey ShiftKey AltKey)∊⊂⊂'true'
      p←k,⍨∊b/'Ctrl' 'Shift' 'Alt'

--- a/APLSource/Main/OnKeyDown.aplf
+++ b/APLSource/Main/OnKeyDown.aplf
@@ -6,10 +6,18 @@
      ⍝ let its keystrokes bubble on and fire the app's KeyDown handler - e.g. Escape must
      ⍝ close the menu only, not reach a user handler that might read it as "close the app" (#82).
      0<≢d GetElementsByClass'menu':0
+     ⍝ Likewise once the menu bar is activated (F10) but no menu is dropped down yet: its own
+     ⍝ handler deals with Escape (deactivate) / arrows / Enter, so the key must not leak either.
+     {2≠⍵.⎕NC'class':0 ⋄ (⊂'MenuBar')∊' '(≠⊆⊢)⍵.class}⍵.Target:0
      k←⍵.Code
      b←⍵.(CtrlKey ShiftKey AltKey)∊⊂⊂'true'
      p←k,⍨∊b/'Ctrl' 'Shift' 'Alt'
      ⍵.FQK←p
+     ⍝ F10 activates the menu bar (Windows/Linux standard): move keyboard focus onto it;
+     ⍝ the MenuBar's own key handlers then navigate (arrows) and open menus (Enter/↓).
+     ⍝ Only consume F10 when a menu bar exists, so apps without one still receive the key.
+     mb←{p≢'F10':⍬ ⋄ ⍵ GetElementsByClass'MenuBar'}d
+     0<≢mb:{⍵.Document ExecuteJavaScript'var e=document.getElementById("',⍵.id,'");e._prevFocus=document.activeElement;e.focus();'}⊃mb
      _←OnKeyDownGlobal ⍵  ⍝ 0  ⍝ Handle main menu shortcuts
      d←⍵.Document
      e←⎕NS''


### PR DESCRIPTION
Menu-bar keyboard handling and a menu-click fix. Three independent commits, one per issue.

### Fix #88 — F10 activates the menu bar (Escape deactivates)
- **F10** moves keyboard focus onto the menu bar (Windows/Linux standard; a harmless no-op on macOS, where F10 defaults to a hardware media key). It's only consumed when a menu bar exists, so apps without one still receive the key.
- Once focused, the bar's existing handlers navigate (arrows) and open menus (Enter / ↓).
- **Escape** blurs the bar and returns focus to wherever F10 took it from.

### Fix #83 — clicking an open menu's caption closes it
The caption that opened a menu is the popover's invoker, so it's exempt from the browser's light-dismiss; a second click just re-showed the menu. Clicking the open caption now toggles it shut. The `Active` class is also kept in step with `ActiveIndex` (as the keyboard path already did), so mouse and keyboard selection can't leave a stranded or duplicated highlight.

### Fix #82 — menu keystrokes no longer leak to the app
When a dropdown menu is open, or the menu bar is activated, that element owns the keyboard. The body-level `OnKeyDown` now bows out in both cases, so a keystroke (notably Escape, which closes the menu / deactivates the bar) doesn't also fire the app's `KeyDown` handler and get read as e.g. "close the app".

### Also completes #88 for the mouse — so far only the keyboard was supported
Clicking a caption to open a menu now remembers the previous focus (before the click shifts focus to the bar) — so when the menu is closed with `<Escape>` it hands it back exactly as it does after F10. The precise caret/selection (start, end, direction) is captured on the way out (`OnKeyDown` for F10, `NewMenuBar` for the mouse) and reinstated in `OnKeyDownMenuBar`'s Escape handler, which also sets a one-shot `_keepSelection` flag so a `SelectOnFocus` input does not collapse it first.

`_keepSelection` is set in #90's `OnKeyDownMenuBar` and read in #94's `InitSelectOnFocus`, so the "keep selection on menu-Escape" behaviour only fully lights up once both are merged.

---
Independent of PR #79/#89 — touches only `OnKeyDown.aplf`, `Menu/OnKeyDownMenuBar.aplf`, `Menu/OnClickMenuBar.aplf`, `Menu/NewMenuBar.aplf`.
