### PR TITLE
Fix #91: focus no longer shifts layout (keep border width constant)

### DIFF
--- a/APLSource/Themes/AbacusDark.aplf
+++ b/APLSource/Themes/AbacusDark.aplf
@@ -10,7 +10,7 @@
      ⍝ Borders
      r.__border_radius←'.5rem'
      r.__border←'2px solid #E5E7EB'
-     r.__border_focused←'3px solid #60A5FA'  ⍝ Was 2
+     r.__border_focused←'2px solid #60A5FA'  ⍝ same width as --border so focus recolours without shifting layout; the box-shadow ring supplies the emphasis
      ⍝ r.__border_box_shadow_focused←'0 0 0 3px rgba(96,165,250,0.35)'
 
      r.__border_box_shadow_focused←'0 0 0 1px #60A5FA, 0 0 0 4px rgba(96,165,250,.25)'


### PR DESCRIPTION
Focusing a control (edit field, button, drop-list, etc.) swapped its border from `--border` (`2px`) to `--border-focused` (`3px`), so the box grew 1px per side and everything below shifted down — visibly ugly.

Fix: make the focused border the **same width** as the resting border (2px), changing only its colour to blue. The existing `--border-box-shadow-focused` ring already supplies the extra emphasis, and box-shadow doesn't affect layout — so the control still reads clearly as focused, but nothing moves.

One line in `Themes/AbacusDark.aplf`. Because every focusable component pulls its focus border from `--border-focused`, this corrects all of them at once (TextInput, Button, DropList, DateInput, CheckBox, NumberInput, RadioGroup, TextArea, Toolbar, Menu).

Fixes #91.
