### PR TITLE
Fix #93: add TextInput SelectOnFocus option

### DIFF
--- a/APLSource/DocSource/ObjectReference/TextInput_Property_SelectOnFocus.md
+++ b/APLSource/DocSource/ObjectReference/TextInput_Property_SelectOnFocus.md
@@ -1,0 +1,9 @@
+# TextInput SelectOnFocus Property
+
+Specifies whether all text is selected when the input receives the focus. Boolean, default 1.
+
+When 0, no text is selected and the caret is placed at the end of the text instead.
+
+## Remarks
+
+This property takes effect only when the input is created. Assigning to it afterwards changes the stored value but has no effect on the control's behaviour.

--- a/APLSource/Main/TextInput/InitSelectOnFocus.aplf
+++ b/APLSource/Main/TextInput/InitSelectOnFocus.aplf
@@ -1,0 +1,12 @@
+ InitSelectOnFocus←{
+     ⍝ ⍺ ←→ Element (Component)
+     ⍝ ⍵ ←→ 1 = browser selects all text on focus (default) | 0 = drop the caret at the end
+     ⍝ Always returns 0
+     ⍺.SelectOnFocus←⍵
+     ⍵:0
+     i←1 0⊃⍺.Content.Content
+     ⍝ Defer: the browser applies its own focus-time selection (select-all) after this handler,
+     ⍝ so a same-tick setSelectionRange is overridden; setTimeout runs it afterwards.
+     i.onfocus←'var t=this;setTimeout(function(){t.setSelectionRange(t.value.length,t.value.length)},0)'
+     0
+ }

--- a/APLSource/Main/TextInput/InitSelectOnFocus.aplf
+++ b/APLSource/Main/TextInput/InitSelectOnFocus.aplf
@@ -1,12 +1,19 @@
  InitSelectOnFocus←{
      ⍝ ⍺ ←→ Element (Component)
-     ⍝ ⍵ ←→ 1 = browser selects all text on focus (default) | 0 = drop the caret at the end
+     ⍝ ⍵ ←→ 1 = select all text on focus (default) | 0 = drop the caret at the end
      ⍝ Always returns 0
      ⍺.SelectOnFocus←⍵
-     ⍵:0
      i←1 0⊃⍺.Content.Content
-     ⍝ Defer: the browser applies its own focus-time selection (select-all) after this handler,
-     ⍝ so a same-tick setSelectionRange is overridden; setTimeout runs it afterwards.
-     i.onfocus←'var t=this;setTimeout(function(){t.setSelectionRange(t.value.length,t.value.length)},0)'
+     ⍝ Do the focus-time action *explicitly* rather than leaning on the browser's native
+     ⍝ select-on-focus: that only fires for keyboard/Tab focus, NOT for programmatic focus
+     ⍝ (A.SetFocus) or autofocus - so a field focused on start-up would otherwise land the caret
+     ⍝ at the end instead of selecting all. Defer via setTimeout so it runs after the browser's
+     ⍝ own same-tick focus handling, which would override an immediate call.
+     act←{⍵:'t.select()' ⋄ 't.setSelectionRange(t.value.length,t.value.length)'}⍵
+     ⍝ Two one-shot escape hatches skip the focus action so an existing selection/caret survives:
+     ⍝  • _keepSelection - set by a focus-restoring caller (e.g. Menu Escape).
+     ⍝  • window return - switching to another app and back re-fires focus (CEF); a self-installing
+     ⍝    window blur/focus tracker marks _winBlurred while inactive, consumed on the return focus.
+     i.onfocus←'var t=this;if(!window._sofInit){window._sofInit=1;addEventListener(''blur'',function(){window._winBlurred=1;});addEventListener(''focus'',function(){setTimeout(function(){window._winBlurred=0;},0);});}if(t._keepSelection){t._keepSelection=false;return;}if(window._winBlurred){window._winBlurred=0;return;}setTimeout(function(){',act,'},0)'
      0
  }

--- a/APLSource/Main/TextInput/New.aplf
+++ b/APLSource/Main/TextInput/New.aplf
@@ -9,6 +9,7 @@
          'OnPicker' ''
          'OnChange' ''
          'Disabled' 0
+         'SelectOnFocus' 1
      )A.Default ⍵
      d.Name←n
      d.Oninput←A.FQP'OnInput'
@@ -20,6 +21,7 @@
      i.id←l.for
      _←i A.AutoComplete.Init d.Options
      _←d InitValue d.Value
+     _←d InitSelectOnFocus d.SelectOnFocus
      0=≢d.OnPicker:d
      b←n A.New'button'd.PickerCaption
      b.Onclick←A.FQP'OnPicker'


### PR DESCRIPTION
Adds a `SelectOnFocus` option to `TextInput` (default `1`). With `0`, the caret is placed at the end of the text on focus instead of selecting all.

Applied at creation only (via `InitSelectOnFocus`, mirroring `InitValue`). I deliberately did **not** add a runtime setter: the effect is a client-side `onfocus` handler, and it must be deferred (`setTimeout`) because the browser applies its own focus-time select-all *after* the handler runs. Toggling it live added complexity for a case with no real need, so I made it a construction-time option — documented as such (`Fixes #93`).

---
The default (1) used to lean on the browsers native select-on-focus, which only fires for keyboard/Tab focus,
so a field focused programmatically (A.SetFocus) or via autofocus landed the caret at the end instead of selecting all. 
InitSelectOnFocus now installs an explicit, deferred onfocus action for both values (select() for 1, caret-to-end for 0). 

Two one-shot escape hatches skip it so an existing selection/caret survives: 
_keepSelection (set by a focus-restoring caller such as the menu Escape) and a self-installing window blur/focus tracker (_winBlurred),
so returning from another window keeps the selection.
