### PR TITLE
Ignore clicks on the already-active tab

### DIFF
--- a/APLSource/Main/Tabs/OnClick.aplf
+++ b/APLSource/Main/Tabs/OnClick.aplf
@@ -1,5 +1,6 @@
  OnClick←{
      b←⍵.CurrentTarget
+     b.Active:0            ⍝ already the active tab → no-op (else Activate hides it)
      n←b.Parent
      i←n.Content⍳b
      t←n.Parent


### PR DESCRIPTION
Clicking a tab that was already active ran Activate again and hid it. Now  a gyard (b.Active:0) prevents this