### PR TITLE
Let OnBeforeClose use Abacus' own modal dialogs

### DIFF
--- a/APLSource/CSVEditor/Close.aplf
+++ b/APLSource/CSVEditor/Close.aplf
@@ -1,5 +1,5 @@
  Close←{
-     ~A.Query'Close' 'Are you sure you want to close?'
-     ⍝ This will not work:
-     ⍝ 'No'≡⍵ A.Confirm'Close' 'Are you sure you want to close?'
+     ⍝ Application OnBeforeClose handler (⍵ ←→ Document). Return 0 to close, 1 to keep open.
+     ⍝ Runs off the UI thread (see Main.RunBeforeClose), so Abacus' own modal dialogs work here.
+     'Yes'≢⍵ A.Confirm'Close' 'Are you sure you want to close?'
  }

--- a/APLSource/DocSource/ObjectReference/Application_Event_BeforeClose.md
+++ b/APLSource/DocSource/ObjectReference/Application_Event_BeforeClose.md
@@ -4,14 +4,52 @@ For a desktop application, this event occurs
 after a user attempts to close the main form or quit the application.
 This provides an opportunity to save state or confirm the action.
 
-For a web application, this event occurrs when the connection is lost
+For a web application, this event occurs when the connection is lost
 or closed.
 
-The left argument to the callback function is the application instance.
-The right argument is an event message containing
-a reference to the document,
-
-For a desktop application, the result should be set to `0` to proceed with the 
-close as requested, or `1` to not close.
+The callback is called monadically; its right argument is the application's
+`Document`. The result must be `0` to proceed with the close as requested,
+or `1` to keep the window open.
 
 There is no way to prevent a web application from closing.
+
+## Remarks
+
+### Abacus' own modal dialogs may be used here
+
+You can call Abacus' own modal boxes — `Confirm`, `Alert`, `Prompt` — directly
+from the `BeforeClose` handler, for example to ask *"Are you sure you want to
+close?"*. This is the recommended, cross-platform way to guard a close; there is
+no need to fall back on a native, Windows-only message box (`⎕WC 'MsgBox'`).
+
+```apl
+Close←{
+    ⍝ ⍵ ←→ Document. Return 0 to close, 1 to keep open.
+    'Yes'≢⍵ A.Confirm'Close' 'Are you sure you want to close?'
+}
+```
+
+`Confirm` returns the caption of the button the user chose (`'Yes'`/`'No'`),
+or an empty vector if the dialog was dismissed with `Escape`. So `'Yes'≢…`
+keeps the window open unless the user explicitly confirms.
+
+### Why this needs care (the deadlock that used to bite)
+
+`Confirm` *blocks* the calling thread on a token (`⎕TGET`) and waits for the
+user's click to arrive back over the websocket and release it. For that to
+work, the thread that dispatches the incoming click must **not** be the one
+that is blocked waiting for it.
+
+The native close notification fires on Abacus' `⎕DQ`/UI thread — the very
+thread that also delivers a modal dialog's click. If the `BeforeClose` handler
+ran there and put up a `Confirm`, it would block that thread and the click
+could never be delivered: the application would **deadlock**. (This is why, in
+earlier versions, a `Confirm` in `BeforeClose` hung and a native message box was
+used instead.)
+
+Abacus now avoids this automatically: it runs the `BeforeClose` handler on a
+**separate thread**, off the UI thread, and only vetoes or performs the close
+once the handler has returned. Your handler therefore does not need to do
+anything special — it may block on a modal dialog freely. As a consequence the
+handler runs *asynchronously*: the window closes a moment after the handler
+returns `0`, not synchronously within the notification.

--- a/APLSource/Main/InitApp.aplf
+++ b/APLSource/Main/InitApp.aplf
@@ -13,6 +13,7 @@
      d.Style←CollectCSS d
      d.NextId←0
      d.Waiting←0
+     d.CloseConfirmed←0
      d.Connected←0
      b←GetBody d
      b.Onkeydown←'OnKeyDown'

--- a/APLSource/Main/OnClose.aplf
+++ b/APLSource/Main/OnClose.aplf
@@ -2,12 +2,15 @@
      ⍝ OnClose of HTMLRenderer created here: NewForm
      h←0⊃⍵
      d←h.Document
+     d.CloseConfirmed:1⊣CloseApp h ⍝ re-close approved by RunBeforeClose → let the native close through
      m←d GetElementsByClass'DialogBox'
-     0<≢m:0
+     0<≢m:0 ⍝ a modal is open (incl. a confirm we may be showing) → keep the window
      a←d.Application
      f←a.OnBeforeClose
-     0=≢f:1⊣CloseApp h
-     r←(⍎f)d
-     r:0
-     1⊣CloseApp h
+     0=≢f:1⊣CloseApp h ⍝ no handler → close
+     ⍝ Run OnBeforeClose on a *separate* thread, off this ⎕DQ/UI thread, so it may use Abacus'
+     ⍝ own modal dialogs (A.Confirm etc.): those block on ⎕TGET and need this thread free to
+     ⍝ deliver the button click. See RunBeforeClose.
+     _←RunBeforeClose&h
+     0 ⍝ veto for now; RunBeforeClose re-issues Close if the handler agrees
  }

--- a/APLSource/Main/RunBeforeClose.aplf
+++ b/APLSource/Main/RunBeforeClose.aplf
@@ -1,0 +1,12 @@
+ RunBeforeClose←{
+     ⍝ Runs the application's OnBeforeClose handler on a thread of its own (spawned from OnClose),
+     ⍝ off the ⎕DQ/UI thread. That frees the handler to use Abacus' own modal dialogs (A.Confirm,
+     ⍝ ...): they block on ⎕TGET and rely on the UI thread staying free to deliver the click.
+     ⍝ ⍵ ←→ HTMLRenderer (Client). Always returns 0.
+     h←⍵
+     d←h.Document
+     f←d.Application.OnBeforeClose
+     (⍎f)d:0 ⍝ handler returned 1 → keep the window open, do nothing
+     d.CloseConfirmed←1 ⍝ handler returned 0 → approve the close ...
+     0⊣Close h ⍝ ... and re-issue it; OnClose now sees the flag and lets it through
+ }


### PR DESCRIPTION
Abacus' own modal dialogs (`A.Confirm` etc.) could not be used in an Application's OnBeforeClose handler: it ran on the `⎕DQ`/UI thread, and a modal there blocks the very thread that must deliver the click back — a deadlock. 

Now `OnBeforeClose` runs on a separate thread (`Main.RunBeforeClose`): the first close is vetoed, the handler runs off the UI thread where it can safely block on a modal, and once it approves the close is re-issued under a `d.CloseConfirmed` flag. 

`CSVEditor.Close` now uses `A.Confirm`; `Application_Event_BeforeClose.md` documents the behaviour and its signature is corrected to the actual monadic form. Note: `OnBeforeClose` is now asynchronous — the window closes a moment after the handler returns 0. Tested on Windows.