### PR TITLE
WebSocketSend: drop sends to a torn-down HTMLRenderer

### DIFF
--- a/APLSource/Main/WebSocketSend.aplf
+++ b/APLSource/Main/WebSocketSend.aplf
@@ -3,6 +3,14 @@
      ⍝ ⍵ ←→ Data to send
      ⍝ Client is HTMLRenderer, or Rumba Connection
      c←⍺.Client
+     ⍝ The Client's HTMLRenderer can already be torn down (window closed / GUI rebuilt) while a
+     ⍝ queued worker-thread handler is still trying to send - e.g. an AutoComplete popover clearing
+     ⍝ its innerHTML as it closes. `Type` is an intrinsic ⎕WC property, present for the whole life
+     ⍝ of the object, so it only vanishes once the object is gone (assigned vars like Document /
+     ⍝ WebSocketID linger in the dead namespace). Treat a missing Type as "no renderer" and drop
+     ⍝ the message rather than crash the worker thread with a VALUE ERROR on c.Type.
+     0=c.⎕NC⊂'Type':0
      c.Type≡'HTMLRenderer':c.WebSocketSend c.WebSocketID ⍵ 1 1
+     6::0
      c.Server.DRC.Send(c.Server.Name,'.',c.Name)(⍵ 1 1)
  }


### PR DESCRIPTION
A queued handler on the worker thread can try to send after its HTMLRenderer is already gone (window closed, or the GUI was rebuilt). For example, an AutoComplete popover clears its innerHTML as it closes.

When that happens, the Client still has `Document` and `WebSocketID`, but the `Type` property is gone with the destroyed object — so reading it throws `VALUE ERROR`, and the worker thread crashes.

The fix: check first with `0=c.⎕NC⊂'Type'`. If `Type` is gone, there is no renderer to talk to, so just drop the message.

Found while building a Fire dialog; not specific to Fire.
