### PR TITLE
Make generated API covers callable monadically (⍺←⊢)

### DIFF
--- a/APLSource/DocSource/BuildAPI.aplf
+++ b/APLSource/DocSource/BuildAPI.aplf
@@ -12,7 +12,7 @@
          c,←⊂'     ⍝ ⍵ ←→ method argument'
          _←s.⎕FX¨{
              d←'     ⍝ Documentation: #.Abacus.DocSource.ObjectReference.',o,'_Method_',⍵
-             (⊂⍵,'←{'),(⊂'     ⍺←⊢    ⍝ default ⍺ so a monadic call passes straight through'),c,d('⍺ A.',(e/o,'.'),⍵,' ⍵')'}'}¨m
+             (⊂⍵,'←{'),c,d('     ⍺←⊢    ⍝ default ⍺ so a monadic call passes straight through')('⍺ A.',(e/o,'.'),⍵,' ⍵')'}'}¨m
          b←(↓t[;0 1])∊⊂⍵'Property'
          v←ObjectReference ⎕VGET b/n
          _←s ⎕VSET(b/t[;2]){⍺ ⍵}¨v

--- a/APLSource/DocSource/BuildAPI.aplf
+++ b/APLSource/DocSource/BuildAPI.aplf
@@ -12,7 +12,7 @@
          c,←⊂'     ⍝ ⍵ ←→ method argument'
          _←s.⎕FX¨{
              d←'     ⍝ Documentation: #.Abacus.DocSource.ObjectReference.',o,'_Method_',⍵
-             (⊂⍵,'←{'),c,d('⍺ A.',(e/o,'.'),⍵,' ⍵')'}'}¨m
+             (⊂⍵,'←{'),(⊂'     ⍺←⊢    ⍝ default ⍺ so a monadic call passes straight through'),c,d('⍺ A.',(e/o,'.'),⍵,' ⍵')'}'}¨m
          b←(↓t[;0 1])∊⊂⍵'Property'
          v←ObjectReference ⎕VGET b/n
          _←s ⎕VSET(b/t[;2]){⍺ ⍵}¨v


### PR DESCRIPTION
Prevents some Value Errors. For example, `API.CSSRule.NewRule`:

```
 NewRule←{
     ⍝ ⍺ ←→ CSSRule instance
     ⍝ ⍵ ←→ method argument
     ⍝ Documentation: #.Abacus.DocSource.ObjectReference.CSSRule_Method_NewRule
     ⍺ A.NewRule ⍵
 }
```