### PR TITLE
Fix DataGrid scrollbar crash when the track is page-clicked

### DIFF
--- a/APLSource/Main/DataGrid/OnScrollBarMouseDown.aplf
+++ b/APLSource/Main/DataGrid/OnScrollBarMouseDown.aplf
@@ -1,6 +1,6 @@
  OnScrollBarMouseDown←{
      tr←⍵.CurrentTarget
-     tr=⍵.Target:ScrollBarMovePage ⍵
+     tr=⍵.Target:ScrollBarMovePage ⍵ ⊣ tr.⎕EX'StartDragMousePosition'   ⍝ track click = page move, not a drag: clear any stale drag origin
      n←⍵.MouseViewportPosition
      m←⍵.CurrentTargetPosition
      tr.StartDragMousePosition←n-m

--- a/APLSource/Main/DataGrid/OnScrollBarMouseMove.aplf
+++ b/APLSource/Main/DataGrid/OnScrollBarMouseMove.aplf
@@ -1,6 +1,7 @@
  OnScrollBarMouseMove←{
      ⍵.MouseButtons≠1:0
      tr←⍵.CurrentTarget
+     0=tr.⎕NC⊂'StartDragMousePosition':0   ⍝ no thumb-drag active (e.g. a page-click on the track) → ignore
      th←⍵.Target
      t←tr.Parent.Table
      n←⍵.MouseViewportPosition


### PR DESCRIPTION
Clicking the scrollbar track (a page-jump, not a thumb-drag) can crash the worker thread with VALUE ERROR: Undefined name: StartDragMousePosition.

It happens only when the mouse is moved while the button is down.

Checking for the existence of StartDragMousePosition avoids the crash.

In OnScrollBarMouseDown, on the track/page path, any stale drag origin needs clearing:

```
tr=⍵.Target:ScrollBarMovePage ⍵ ⊣ tr.⎕EX'StartDragMousePosition'
```

There is no mouseup handler, so once a thumb-drag sets StartDragMousePosition nothing ever clears it; without this a later track-click-plus-jitter would scroll from a stale origin.
