### PR TITLE
Add New constructors to the API for 19 components

### DIFF
--- a/APLSource/DocSource/ObjectReference/Button_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/Button_Method_New.md
@@ -1,0 +1,18 @@
+# Button New Method
+
+Creates a new Button component.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the Button properties. `R` is the new Button.
+
+## Examples
+
+~~~
+      b←A.Button.New'Find'
+      b←A.Button.New(Caption:'Find' ⋄ Shortcut:'Ctrl+F' ⋄ OnClick:A.FQP'OnFind')
+~~~

--- a/APLSource/DocSource/ObjectReference/CheckBox_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/CheckBox_Method_New.md
@@ -1,0 +1,18 @@
+# CheckBox New Method
+
+Creates a new CheckBox component.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the CheckBox properties. `R` is the new CheckBox.
+
+## Examples
+
+~~~
+      cb←A.CheckBox.New'Match case'
+      cb←'MatchCase'A.CheckBox.New(Label:'Match case' ⋄ Value:1)
+~~~

--- a/APLSource/DocSource/ObjectReference/DataGrid_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/DataGrid_Method_New.md
@@ -1,0 +1,18 @@
+# DataGrid New Method
+
+Creates a new DataGrid component.
+
+~~~
+R←{P} New W
+~~~
+
+`P` is an optional parent element. `W` is a namespace (or shortcut list) of properties — see
+the DataGrid properties. `R` is the new DataGrid. The data is supplied through the `Columns`
+property (or, after creation, with `SetColumns`).
+
+## Examples
+
+~~~
+      g←A.DataGrid.New''
+      g←A.DataGrid.New(ReadOnly:1 ⋄ RowNumbers:1)
+~~~

--- a/APLSource/DocSource/ObjectReference/DateInput_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/DateInput_Method_New.md
@@ -1,0 +1,18 @@
+# DateInput New Method
+
+Creates a new DateInput component — a labelled date entry.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the DateInput properties. `R` is the new DateInput.
+
+## Examples
+
+~~~
+      di←A.DateInput.New'Date:'
+      di←A.DateInput.New(Label:'Date:' ⋄ Value:20260810)
+~~~

--- a/APLSource/DocSource/ObjectReference/DialogBox_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/DialogBox_Method_New.md
@@ -1,0 +1,16 @@
+# DialogBox New Method
+
+Creates a new DialogBox component — a modal dialog with a header, content and footer buttons.
+
+~~~
+R←{D} New W
+~~~
+
+`D` is an optional Document. `W` is a namespace (or shortcut list) of properties — see the
+DialogBox properties. `R` is the new DialogBox. Show it with `ShowModal` (or `showModal`).
+
+## Examples
+
+~~~
+      d←doc A.DialogBox.New(Title:'Confirm' ⋄ MainContent:(A.New'p' 'Are you sure?') ⋄ Buttons:'Yes' 'No')
+~~~

--- a/APLSource/DocSource/ObjectReference/DropList_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/DropList_Method_New.md
@@ -1,0 +1,17 @@
+# DropList New Method
+
+Creates a new DropList component — a labelled drop-down selection.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the DropList properties. `R` is the new DropList.
+
+## Examples
+
+~~~
+      dl←A.DropList.New(Label:'Colour:' ⋄ Options:'Red' 'Green' 'Blue')
+~~~

--- a/APLSource/DocSource/ObjectReference/FieldSet_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/FieldSet_Method_New.md
@@ -1,0 +1,17 @@
+# FieldSet New Method
+
+Creates a new FieldSet component — a bordered group of controls with an optional legend.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the FieldSet properties. `R` is the new FieldSet.
+
+## Examples
+
+~~~
+      fs←A.FieldSet.New(Content:(cb1 cb2) ⋄ Legend:'Options' ⋄ Border:1)
+~~~

--- a/APLSource/DocSource/ObjectReference/FileInput_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/FileInput_Method_New.md
@@ -1,0 +1,17 @@
+# FileInput New Method
+
+Creates a new FileInput component — a TextInput with a button to browse for a file.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the FileInput properties. `R` is the new FileInput.
+
+## Examples
+
+~~~
+      fi←A.FileInput.New'File:'
+~~~

--- a/APLSource/DocSource/ObjectReference/Flex_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/Flex_Method_New.md
@@ -1,0 +1,17 @@
+# Flex New Method
+
+Creates a new Flex component — a flexbox container.
+
+~~~
+R←{P} New W
+~~~
+
+`P` is an optional parent element. `W` is a namespace (or shortcut list) of properties — see
+the Flex properties. `R` is the new Flex.
+
+## Examples
+
+~~~
+      f←A.Flex.New(Content:(a b c))
+      f←A.Flex.New(Content:(a b) ⋄ _gap:'1rem' ⋄ _align_items:'center')
+~~~

--- a/APLSource/DocSource/ObjectReference/ListView_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/ListView_Method_New.md
@@ -1,0 +1,16 @@
+# ListView New Method
+
+Creates a new ListView component.
+
+~~~
+R←{P} New W
+~~~
+
+`P` is an optional parent element. `W` is a namespace (or shortcut list) of properties — see
+the ListView properties. `R` is the new ListView.
+
+## Examples
+
+~~~
+      lv←A.ListView.New(Items:'Apple' 'Pear' 'Plum')
+~~~

--- a/APLSource/DocSource/ObjectReference/Menu_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/Menu_Method_New.md
@@ -1,0 +1,19 @@
+# Menu New Method
+
+Creates a new Menu — a `<menu>` element. With no parent it is a top-level menu (the root of
+a context menu); given a parent menu it is a submenu of that menu.
+
+~~~
+R←{P} New W
+~~~
+
+`P` is an optional parent menu. If omitted, the result is a top-level menu; if a parent menu
+is given, the result is a submenu of it. `W` is a namespace (or shortcut list) of properties
+— see the Menu properties. `R` is the new Menu.
+
+## Examples
+
+~~~
+      m←A.Menu.New''                   ⍝ root menu (e.g. for a context menu)
+      sub←m A.Menu.New(Label:'File')   ⍝ a submenu of m
+~~~

--- a/APLSource/DocSource/ObjectReference/NumberInput_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/NumberInput_Method_New.md
@@ -1,0 +1,18 @@
+# NumberInput New Method
+
+Creates a new NumberInput component — a labelled numeric entry.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the NumberInput properties. `R` is the new NumberInput.
+
+## Examples
+
+~~~
+      ni←A.NumberInput.New'Count:'
+      ni←A.NumberInput.New(Label:'Count:' ⋄ Value:0 ⋄ Format:'I10')
+~~~

--- a/APLSource/DocSource/ObjectReference/Panels_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/Panels_Method_New.md
@@ -1,0 +1,16 @@
+# Panels New Method
+
+Creates a new Panels component — a (optionally resizable) CSS-grid layout.
+
+~~~
+R←{P} New W
+~~~
+
+`P` is an optional parent element. `W` is a namespace (or shortcut list) of properties — see
+the Panels properties. `R` is the new Panels.
+
+## Examples
+
+~~~
+      pn←A.Panels.New(Content:(left right) ⋄ GridTemplateColumns:'1fr' '2fr' ⋄ Resizeable:1)
+~~~

--- a/APLSource/DocSource/ObjectReference/RadioGroup_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/RadioGroup_Method_New.md
@@ -1,0 +1,17 @@
+# RadioGroup New Method
+
+Creates a new RadioGroup component — a labelled set of radio buttons.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the RadioGroup properties. `R` is the new RadioGroup.
+
+## Examples
+
+~~~
+      rg←A.RadioGroup.New(Legend:'Size' ⋄ Labels:('Small' 'Medium' 'Large') ⋄ Options:1 2 3)
+~~~

--- a/APLSource/DocSource/ObjectReference/Tabs_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/Tabs_Method_New.md
@@ -1,0 +1,16 @@
+# Tabs New Method
+
+Creates a new Tabs component.
+
+~~~
+R←{P} New W
+~~~
+
+`P` is an optional parent element. `W` is a namespace (or shortcut list) of properties — see
+the Tabs properties. `R` is the new Tabs.
+
+## Examples
+
+~~~
+      t←A.Tabs.New(TabContent:(page1 page2) ⋄ Captions:'Overview' 'Details' ⋄ OnActivate:A.FQP'OnActivate')
+~~~

--- a/APLSource/DocSource/ObjectReference/TextArea_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/TextArea_Method_New.md
@@ -1,0 +1,18 @@
+# TextArea New Method
+
+Creates a new TextArea component — a labelled multi-line text entry.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the TextArea properties. `R` is the new TextArea.
+
+## Examples
+
+~~~
+      ta←A.TextArea.New'Notes:'
+      ta←A.TextArea.New(Label:'Notes:' ⋄ Value:'initial text')
+~~~

--- a/APLSource/DocSource/ObjectReference/TextInput_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/TextInput_Method_New.md
@@ -1,0 +1,19 @@
+# TextInput New Method
+
+Creates a new TextInput component — a labelled text entry, with optional autocomplete and
+an optional picker button.
+
+~~~
+R←{PN} New W
+~~~
+
+`PN` is an optional parent element, a name, or a `(parent name)` pair; if omitted, the
+name is taken from the variable the result is assigned to. `W` is a namespace (or shortcut
+list) of properties — see the TextInput properties. `R` is the new TextInput.
+
+## Examples
+
+~~~
+      ti←A.TextInput.New'Search for:'
+      ti←'SearchFor'A.TextInput.New(Label:'Search for:' ⋄ Options:'a' 'cause' '⎕IO')
+~~~

--- a/APLSource/DocSource/ObjectReference/Toolbar_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/Toolbar_Method_New.md
@@ -1,0 +1,16 @@
+# Toolbar New Method
+
+Creates a new Toolbar component.
+
+~~~
+R←{P} New W
+~~~
+
+`P` is an optional parent element. `W` is a namespace (or shortcut list) of properties — see
+the Toolbar properties. `R` is the new Toolbar.
+
+## Examples
+
+~~~
+      tb←A.Toolbar.New(Content:buttons)
+~~~

--- a/APLSource/DocSource/ObjectReference/TreeView_Method_New.md
+++ b/APLSource/DocSource/ObjectReference/TreeView_Method_New.md
@@ -1,0 +1,16 @@
+# TreeView New Method
+
+Creates a new TreeView component.
+
+~~~
+R←{P} New W
+~~~
+
+`P` is an optional parent element. `W` is a namespace (or shortcut list) of properties — see
+the TreeView properties. `R` is the new TreeView.
+
+## Examples
+
+~~~
+      tv←A.TreeView.New(Items:items ⋄ Depth:depths)
+~~~


### PR DESCRIPTION
The generated API had no way to construct a component — there was no `New` for `CheckBox`, `TextInput`, `DataGrid`, and so on. This adds a `<Component>_Method_New.md` page for each, so `BuildAPI` generates `API.<Component>.New`.

Depends on #104 (the `⍺←⊢` cover change): most constructors are called monadically (e.g. `A.CheckBox.New'label'`), so they only work once the covers are valence-transparent. Merge #104 first.

Components covered (19): 

```
CheckBox, TextInput, TextArea, NumberInput, DateInput, DropList, RadioGroup, Button, FileInput, FieldSet, DataGrid, Tabs, Panels, Flex, Toolbar, ListView, TreeView, DialogBox, Menu
```

`Menu.New` is included because it is required to build a context menu through the API (`A.Menu.New''` for the root, submenus with a parent menu). `API.Menu` already had `NewMenuBar/NewDropdownMenu/NewItem/ShowContextMenu`; this adds the plain `New`.

Deliberately left out:

* `PickList` — left alone (its `New` looks internal).
* `ProgressBar` — no `New`; it is built with `Create` (already in the API).
* `Alert` / `Confirm` / `Prompt` — possibly to become top-level `API.Alert` etc. in a later PR
* `AutoComplete`, `ToolTip`, `FindAndReplace` — skipped (helpers / composite).

Each page follows the existing `HTMLElement_Method_New` style (description, signature, parameters, example).
